### PR TITLE
wait for container to be healthy if already started

### DIFF
--- a/src/main/kotlin/io/github/corbym/dokker/DokkerContainer.kt
+++ b/src/main/kotlin/io/github/corbym/dokker/DokkerContainer.kt
@@ -15,6 +15,8 @@ class DokkerContainer(
             debug("starting container: $name with exposed ports $expose$withPublishedPorts ")
             checkContainerStopped()
             onStart(this, dokkerRunCommandBuilder.buildRunCommand().runCommand())
+        } else {
+            waitForHealthCheck()
         }
     }
 


### PR DESCRIPTION
During parallel build execution, some tests are using same containers. First lib may run start and 2nd lib will do hasStarted at the same time. Because hasStarted will return true - it will start executing tests, but container is not yet healthy