### PR TITLE
Exact name match for healthcheck command

### DIFF
--- a/src/main/kotlin/io/github/corbym/dokker/DokkerContainer.kt
+++ b/src/main/kotlin/io/github/corbym/dokker/DokkerContainer.kt
@@ -21,7 +21,7 @@ class DokkerContainer(
     }
 
     private fun checkContainerStopped(errorMessage: String = "Container $name is already stopped and won't be restarted.") {
-        val response = "docker container ls -a -f name=$name --format '{{.Status}}'".runCommand()
+        val response = "docker container ls --all --filter name=^/$name$ --format '{{.Status}}'".runCommand()
         if (response.contains("Exited")) {
             error(
                 """$errorMessage

--- a/src/test/kotlin/io/github/corbym/DokkerHealthcheckTest.kt
+++ b/src/test/kotlin/io/github/corbym/DokkerHealthcheckTest.kt
@@ -1,0 +1,55 @@
+package io.github.corbym
+
+import io.github.corbym.dokker.dokker
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class DokkerHealthcheckTest {
+    val container = dokker {
+        detach()
+        name("db")
+        image("postgres:15")
+        env(
+            "POSTGRES_HOST_AUTH_METHOD" to "trust"
+        )
+        publish(
+            "5432" to "5432"
+        )
+        healthCheck {
+            checking {
+                """psql -U postgres -c "SELECT 'ready'"""" to "ready"
+            }
+        }
+    }
+    val initContainer = dokker {
+        name("db-init")
+        image("postgres:15")
+        command {
+            """ls"""
+        }
+    }
+
+    @BeforeEach
+    fun `start containers`() {
+        container.start()
+        container.waitForHealthCheck()
+        initContainer.start()
+    }
+
+    @AfterEach
+    fun `stop containers`() {
+        initContainer.stop()
+        initContainer.remove()
+        container.stop()
+        container.remove()
+    }
+
+    @Test
+    fun `healthcheck runs against correct container`() {
+        container.waitForHealthCheck()
+        assertThat(container.hasStarted(), equalTo(true))
+    }
+}


### PR DESCRIPTION
The healthcheck captures other similarly named containers. Makes the filtering an exact match.