### PR TITLE
Feature/support podman

### DIFF
--- a/src/main/kotlin/io/github/corbym/dokker/DokkerContainer.kt
+++ b/src/main/kotlin/io/github/corbym/dokker/DokkerContainer.kt
@@ -14,8 +14,6 @@ class DokkerContainer(
         if (!hasStarted()) {
             debug("starting container: $name with exposed ports $expose$withPublishedPorts ")
             checkContainerStopped()
-            // force networks to exist
-            dokkerRunCommandBuilder.networks.forEach { DokkerNetwork(dokkerRunCommandBuilder.process, it).start() }
             onStart(this, dokkerRunCommandBuilder.buildRunCommand().runCommand())
         } else {
             waitForHealthCheck()

--- a/src/main/kotlin/io/github/corbym/dokker/DokkerNetwork.kt
+++ b/src/main/kotlin/io/github/corbym/dokker/DokkerNetwork.kt
@@ -3,11 +3,11 @@ package io.github.corbym.dokker
 import io.github.corbym.dokker.DokkerContainer.Companion.runCommand
 import java.time.Duration
 
-class DokkerNetwork(private val networkName: String) : DokkerLifecycle {
+class DokkerNetwork(private val process: String, private val networkName: String) : DokkerLifecycle {
     override val name = networkName
     override fun start() {
         if (!hasStarted())
-            "docker network create $networkName".runCommand()
+            "$process network create $networkName".runCommand()
     }
 
     override fun stop() {
@@ -16,9 +16,9 @@ class DokkerNetwork(private val networkName: String) : DokkerLifecycle {
 
     override fun remove() {
         awaitUntil(timeout = Duration.ofMinutes(1)) {
-            "docker network rm $networkName".runCommand() == networkName
+            "$process network rm $networkName".runCommand() == networkName
         }
     }
 
-    override fun hasStarted(): Boolean = "docker network ls".runCommand().contains(networkName)
+    override fun hasStarted(): Boolean = "$process network ls".runCommand().contains(networkName)
 }

--- a/src/main/kotlin/io/github/corbym/dokker/DokkerProperties.kt
+++ b/src/main/kotlin/io/github/corbym/dokker/DokkerProperties.kt
@@ -1,6 +1,7 @@
 package io.github.corbym.dokker
 
 interface DokkerProperties {
+    val process: String
     val name: String
     val networks: List<String>
     var expose: List<String>

--- a/src/main/kotlin/io/github/corbym/dokker/DokkerRunCommandBuilder.kt
+++ b/src/main/kotlin/io/github/corbym/dokker/DokkerRunCommandBuilder.kt
@@ -1,6 +1,7 @@
 package io.github.corbym.dokker
 
 class DokkerRunCommandBuilder(
+    override val process: String,
     override val name: String,
     override val networks: List<String>,
     override var expose: List<String>,
@@ -14,7 +15,7 @@ class DokkerRunCommandBuilder(
     override var user: String? = null,
     override vararg val options: Option,
 ) : DokkerProperties {
-    fun buildRunCommand(): String = "docker run${buildOptions()} ${buildImage()}${command?.prefix(" ") ?: ""}"
+    fun buildRunCommand(): String = "$process run${buildOptions()} ${buildImage()}${command?.prefix(" ") ?: ""}"
     private fun buildOptions() = listOf(
         listOf(buildFlags()),
         buildName(),

--- a/src/main/kotlin/io/github/corbym/dokker/dokker.kt
+++ b/src/main/kotlin/io/github/corbym/dokker/dokker.kt
@@ -12,6 +12,7 @@ fun dokker(init: DokkerContainerBuilder.() -> Unit): DokkerContainer {
 @Suppress("unused")
 class DokkerContainerBuilder {
     private var onStart: (DokkerContainer, String) -> Unit = { _, _ -> }
+    private var process: String = "docker"
     private var name: String = "dockerContainer-${UUID.randomUUID()}"
     private val networks: MutableList<String> = mutableListOf()
     private var expose: MutableList<String> = mutableListOf()
@@ -30,6 +31,11 @@ class DokkerContainerBuilder {
     private var detach: Boolean = false
 
     private var debug: Boolean = false
+
+    fun process(process: String) {
+        this.process = process
+    }
+
     fun name(name: String) {
         this.name = name
     }
@@ -101,6 +107,7 @@ class DokkerContainerBuilder {
     fun build(): DokkerContainer {
         return DokkerContainer(
             DokkerRunCommandBuilder(
+                process = process,
                 name = name,
                 networks = networks,
                 expose = expose,

--- a/src/test/kotlin/io/github/corbym/DokkerTest.kt
+++ b/src/test/kotlin/io/github/corbym/DokkerTest.kt
@@ -9,6 +9,8 @@ class DokkerTest {
 
     @Test
     fun `can start helloworld docker container`() {
+        // By setting the environment variable, we can toggle on the 'process' name
+        // this test has out-of-process dependencies, so unable to split the test out
         val dokkerContainer = dokker {
             name("hello-world")
             image { "hello-world" }
@@ -17,34 +19,18 @@ class DokkerTest {
         }
 
         try {
+
             dokkerContainer.also {
                 it.onStart = { _, runResponse ->
-                    assertThat(runResponse, containsString("Hello "))
+                    if (dokkerContainer.process.endsWith("docker")) {
+                        assertThat(runResponse, containsString("Hello from Docker!"))
+                    } else {
+                        assertThat(runResponse, containsString("Hello Podman World"))
+                    }
                 }
             }.start()
         } finally {
             dokkerContainer.remove()
         }
     }
-
-//    @Test
-//    fun `can use alternate like podman`() {
-//        val dokkerContainer = dokker {
-//            process("podman")
-//            name("hello-podman-world")
-//            image { "hello-world" }
-//            version { "latest" }
-//            debug()
-//        }
-//
-//        try {
-//            dokkerContainer.also {
-//                it.onStart = { _, runResponse ->
-//                    assertThat(runResponse, containsString("Hello Podman World"))
-//                }
-//            }.start()
-//        } finally {
-//            dokkerContainer.remove()
-//        }
-//    }
 }

--- a/src/test/kotlin/io/github/corbym/DokkerTest.kt
+++ b/src/test/kotlin/io/github/corbym/DokkerTest.kt
@@ -6,20 +6,45 @@ import org.junit.jupiter.api.Test
 import io.github.corbym.dokker.dokker
 
 class DokkerTest {
-    val dokkerContainer = dokker {
-        name("hello-world")
-        image { "hello-world" }
-        version { "latest" }
-        debug()
-    }
 
     @Test
     fun `can start helloworld docker container`() {
-        dokkerContainer.also {
-            it.onStart = { _, runResponse ->
-                assertThat(runResponse, containsString("Hello from Docker!"))
-            }
-        }.start()
-        dokkerContainer.remove()
+        val dokkerContainer = dokker {
+            name("hello-world")
+            image { "hello-world" }
+            version { "latest" }
+            debug()
+        }
+
+        try {
+            dokkerContainer.also {
+                it.onStart = { _, runResponse ->
+                    assertThat(runResponse, containsString("Hello "))
+                }
+            }.start()
+        } finally {
+            dokkerContainer.remove()
+        }
     }
+
+//    @Test
+//    fun `can use alternate like podman`() {
+//        val dokkerContainer = dokker {
+//            process("podman")
+//            name("hello-podman-world")
+//            image { "hello-world" }
+//            version { "latest" }
+//            debug()
+//        }
+//
+//        try {
+//            dokkerContainer.also {
+//                it.onStart = { _, runResponse ->
+//                    assertThat(runResponse, containsString("Hello Podman World"))
+//                }
+//            }.start()
+//        } finally {
+//            dokkerContainer.remove()
+//        }
+//    }
 }

--- a/src/test/kotlin/io/github/corbym/junit5/ExampleJUnit5DokkerTest.kt
+++ b/src/test/kotlin/io/github/corbym/junit5/ExampleJUnit5DokkerTest.kt
@@ -1,6 +1,7 @@
 package io.github.corbym.junit5
 
 import io.github.corbym.dokker.DokkerContainer.Companion.runCommand
+import io.github.corbym.dokker.DokkerAutoProcessSearchResult
 import io.github.corbym.dokker.awaitUntil
 import io.github.corbym.dokker.junit5.BeforeAllStarter
 import org.junit.jupiter.api.Test
@@ -15,7 +16,7 @@ class ExampleJUnit5DokkerTest {
         val name = "couchbase"
         assertTrue(BeforeAllStarter.hasStarted(name)!!)
         awaitUntil(Duration.ofMinutes(5)) {
-            "docker ps --filter name=$name".runCommand().contains(name)
+            "${DokkerAutoProcessSearchResult.processName} ps --filter name=$name".runCommand().contains(name)
         }
     }
 }


### PR DESCRIPTION
#### Remove "docker" process requirement.

Provide means to specify a "process" to use (of course, the process must understand the docker commands used through out the code base).

Process specification process is:

1. process name set in code (if set, DokkerAutoProcessSearchResult.processName is not used)
```
dokker {
  process("specificProcessName") ...
}
```
2. Otherwise, we check that any of the following process names exists in the path (by invoking 'command -v', which should exist in WSL as well)
    - environment variable
    - hardcoded "docker"
    - hardcoded "podman"
