### PR TITLE
remove command lookup, either use system variable or process config only

### DIFF
--- a/src/main/kotlin/io/github/corbym/dokker/dokker.kt
+++ b/src/main/kotlin/io/github/corbym/dokker/dokker.kt
@@ -9,10 +9,8 @@ fun dokker(init: DokkerContainerBuilder.() -> Unit): DokkerContainer {
     return DokkerContainerBuilder().apply(init).build()
 }
 
-object DokkerAutoProcessSearchResult {
-    val processName: String = run {
-        System.getenv("DOKKER_PROCESS") ?: "docker"
-    }
+object DokkerProcessName {
+    val processName: String = System.getenv("DOKKER_PROCESS") ?: "docker"
 }
 
 @Suppress("unused")
@@ -113,7 +111,7 @@ class DokkerContainerBuilder {
     fun build(): DokkerContainer {
         return DokkerContainer(
             DokkerRunCommandBuilder(
-                process = process ?: DokkerAutoProcessSearchResult.processName,
+                process = process ?: DokkerProcessName.processName,
                 name = name,
                 networks = networks,
                 expose = expose,

--- a/src/main/kotlin/io/github/corbym/dokker/dokker.kt
+++ b/src/main/kotlin/io/github/corbym/dokker/dokker.kt
@@ -11,8 +11,7 @@ fun dokker(init: DokkerContainerBuilder.() -> Unit): DokkerContainer {
 
 object DokkerAutoProcessSearchResult {
     val processName: String = run {
-        val configured: String? = System.getenv("DOKKER_PROCESS")
-        listOfNotNull(configured, "docker").first()
+        System.getenv("DOKKER_PROCESS") ?: "dokker"
     }
 }
 

--- a/src/main/kotlin/io/github/corbym/dokker/dokker.kt
+++ b/src/main/kotlin/io/github/corbym/dokker/dokker.kt
@@ -1,6 +1,5 @@
 package io.github.corbym.dokker
 
-import io.github.corbym.dokker.DokkerContainer.Companion.runCommand
 import io.github.corbym.dokker.OptionType.DETACH
 import io.github.corbym.dokker.OptionType.INTERACTIVE
 import java.time.Duration
@@ -10,24 +9,10 @@ fun dokker(init: DokkerContainerBuilder.() -> Unit): DokkerContainer {
     return DokkerContainerBuilder().apply(init).build()
 }
 
-// Search order is
-// 1. process name set in code (if set, DokkerAutoProcessSearchResult.processName is not used)
-// 2. environment variable (if found in path)
-// 3. hardcoded "docker" (if found in path)
-// 3. hardcoded "podman" (if found in path)
 object DokkerAutoProcessSearchResult {
-
-    // Note that "command -v" - this is best-effort as adding an 'alias' will cause issues
-    // MacOS defaults to zsh shell.
-    //   Intellij does not read ~/.zprofile nor ~/.zshrc scripts so set environment variables in ~/.profile
-    //   Otherwise, "command -v" may not find the executable
-    private fun processFullPath(process: String): String? =
-        "sh -c".runCommand(parameter = "command -v $process", fail = false).ifBlank { null }
-
-    // This name is in an object so that we do this once per process, as this check is expensive
     val processName: String = run {
         val configured: String? = System.getenv("DOKKER_PROCESS")
-        requireNotNull(listOfNotNull(configured, "docker", "podman").firstNotNullOfOrNull { processFullPath(it) }) {
+        requireNotNull(listOfNotNull(configured, "docker").firstOrNull()) {
             """
                 Unable to find an underlying process executable.
                 Please make sure that any of the supporting application process is available and on the PATH

--- a/src/main/kotlin/io/github/corbym/dokker/dokker.kt
+++ b/src/main/kotlin/io/github/corbym/dokker/dokker.kt
@@ -11,7 +11,7 @@ fun dokker(init: DokkerContainerBuilder.() -> Unit): DokkerContainer {
 
 object DokkerAutoProcessSearchResult {
     val processName: String = run {
-        System.getenv("DOKKER_PROCESS") ?: "dokker"
+        System.getenv("DOKKER_PROCESS") ?: "docker"
     }
 }
 

--- a/src/main/kotlin/io/github/corbym/dokker/dokker.kt
+++ b/src/main/kotlin/io/github/corbym/dokker/dokker.kt
@@ -12,15 +12,7 @@ fun dokker(init: DokkerContainerBuilder.() -> Unit): DokkerContainer {
 object DokkerAutoProcessSearchResult {
     val processName: String = run {
         val configured: String? = System.getenv("DOKKER_PROCESS")
-        requireNotNull(listOfNotNull(configured, "docker").firstOrNull()) {
-            """
-                Unable to find an underlying process executable.
-                Please make sure that any of the supporting application process is available and on the PATH
-                1. Current env configured DOKKER_PROCESS: $configured
-                2. docker
-                3. podman
-            """.trimIndent()
-        }
+        listOfNotNull(configured, "docker").first()
     }
 }
 

--- a/src/test/kotlin/io/github/corbym/junit5/ExampleJUnit5DokkerTest.kt
+++ b/src/test/kotlin/io/github/corbym/junit5/ExampleJUnit5DokkerTest.kt
@@ -1,7 +1,7 @@
 package io.github.corbym.junit5
 
 import io.github.corbym.dokker.DokkerContainer.Companion.runCommand
-import io.github.corbym.dokker.DokkerAutoProcessSearchResult
+import io.github.corbym.dokker.DokkerProcessName
 import io.github.corbym.dokker.awaitUntil
 import io.github.corbym.dokker.junit5.BeforeAllStarter
 import org.junit.jupiter.api.Test
@@ -16,7 +16,7 @@ class ExampleJUnit5DokkerTest {
         val name = "couchbase"
         assertTrue(BeforeAllStarter.hasStarted(name)!!)
         awaitUntil(Duration.ofMinutes(5)) {
-            "${DokkerAutoProcessSearchResult.processName} ps --filter name=$name".runCommand().contains(name)
+            "${DokkerProcessName.processName} ps --filter name=$name".runCommand().contains(name)
         }
     }
 }


### PR DESCRIPTION
It's far too complicated to figure out where the process is on a window machine, and a lot of IDEs run without WSL. We can't look the process up for every system available, it'd be a nightmare.

Instead, if you have podman use the system variable or config to set the process. This removes the complexity out of the lib and into the caller